### PR TITLE
create store with redux-toolkit (rtk)

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -34,7 +34,7 @@ const tsRules = {
             readonly: 'generic',
         },
     ],
-    '@typescript-eslint/no-fallthrough': ['warn', { commentPattern: 'break[\\s\\w]*omitted' }],
+    'no-fallthrough': ['warn', { commentPattern: 'break[\\s\\w]*omitted' }],
     '@typescript-eslint/ban-types': [
         'error',
         {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,18 +1,22 @@
 {
   "name": "windy-plugin-sounding",
-  "version": "3.0.0",
+  "version": "3.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "windy-plugin-sounding",
-      "version": "3.0.0",
+      "version": "3.0.5",
       "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "^2.2.3"
+      },
       "devDependencies": {
         "@rollup/plugin-alias": "^5.1.0",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-replace": "^5.0.5",
+        "@types/node": "^20.12.10",
         "@windycom/plugin-devtools": "^1.0.9",
         "eslint": "^8.57.0",
         "eslint-plugin-react": "^7.34.1",
@@ -284,6 +288,29 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.3.tgz",
+      "integrity": "sha512-76dll9EnJXg4EVcI5YNxZA/9hSAmZsFqzMmNRHvIlzw2WS/twfcVX3ysYrWGJMClwEmChQFC4yRq74tn6fdzRA==",
+      "dependencies": {
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.0.1"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/plugin-alias": {
@@ -860,6 +887,15 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/node": {
+      "version": "20.12.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.10.tgz",
+      "integrity": "sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
     "node_modules/@types/pug": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.10.tgz",
@@ -892,7 +928,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
       "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
@@ -3655,6 +3691,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immer": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.1.tgz",
+      "integrity": "sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4153,7 +4198,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -4354,7 +4399,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -5127,7 +5172,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
+      "devOptional": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -5146,7 +5191,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
       "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.3",
         "use-sync-external-store": "^1.0.0"
@@ -5172,14 +5217,12 @@
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "dev": true
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
       "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
-      "dev": true,
       "peerDependencies": {
         "redux": "^5.0.0"
       }
@@ -5226,8 +5269,7 @@
     "node_modules/reselect": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.0.tgz",
-      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg==",
-      "dev": true
+      "integrity": "sha512-aw7jcGLDpSgNDyWBQLv2cedml85qd95/iszJjN988zX1t7AVRJi19d9kto5+W7oCfQ94gyo40dVbT6g2k4/kXg=="
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -6672,6 +6714,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
@@ -6721,7 +6769,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@rollup/plugin-commonjs": "^25.0.7",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-replace": "^5.0.5",
+    "@types/node": "^20.12.10",
     "@windycom/plugin-devtools": "^1.0.9",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.34.1",
@@ -40,5 +41,8 @@
     "svelte-preprocess": "^5.1.3",
     "typescript": "^5.4.4",
     "typescript-eslint": "^7.5.0"
+  },
+  "dependencies": {
+    "@reduxjs/toolkit": "^2.2.3"
   }
 }

--- a/src/sounding.tsx
+++ b/src/sounding.tsx
@@ -8,7 +8,7 @@ import {
   setModelName,
   setTime,
 } from "./actions/sounding.js";
-import { getStore, updateMetrics } from "./util/store.js";
+import { getStore, updateMetrics, AppStore } from "./util/store.js";
 // eslint-disable-next-line no-unused-vars
 import { h, render } from "preact";
 
@@ -22,7 +22,6 @@ import windyStore from "@windy/store";
 import windyUtils from "@windy/utils";
 import { map as windyMap } from "@windy/map";
 import { emitter as windyPicker } from "@windy/picker";
-import { Store } from "redux";
 
 import favs from '@windy/userFavs';
 import { singleclick } from '@windy/singleclick';
@@ -34,7 +33,7 @@ import { centerMap, updateTime } from "./selectors/sounding.js";
 
 declare const SwipeListener: any;
 
-let store: Store;
+let store: AppStore;
 
 export const mountPlugin = (container: HTMLDivElement) => {
   store = getStore(container);
@@ -74,7 +73,7 @@ export const openPlugin = (ll?: LatLon) => {
   if (!ll) {
     const c = windyMap.getCenter();
     lat = c.lat;
-    lon = c.lng;    
+    lon = c.lng;
   } else {
     lat = Number(ll.lat);
     lon = Number(ll.lon);
@@ -137,7 +136,6 @@ export const destroyPlugin = () => {
 };
 
 const setCurrentLocation = (ll: LatLon) => {
-  const {lat, 
-    lon} = ll;
+  const {lat, lon} = ll;
   store.dispatch(setLocation(lat, lon));
 };

--- a/src/util/store.ts
+++ b/src/util/store.ts
@@ -20,10 +20,10 @@ export function getStore(container: HTMLDivElement): AppStore {
   });
 
   // TODO: mobile dimension
-  const graphWith = container.clientWidth;
-  const graphHeight = Math.min(graphWith, window.innerHeight * 0.7);
+  const graphWidth = container.clientWidth;
+  const graphHeight = Math.min(graphWidth, window.innerHeight * 0.7);
 
-  store.dispatch(soundingAct.setWidth(graphWith));
+  store.dispatch(soundingAct.setWidth(graphWidth));
   store.dispatch(soundingAct.setHeight(graphHeight));
 
   updateMetrics(store);

--- a/src/util/store.ts
+++ b/src/util/store.ts
@@ -1,26 +1,23 @@
-import { Store, applyMiddleware, compose, createStore } from "redux";
-import { thunk } from "redux-thunk";
+import { configureStore, EnhancedStore } from '@reduxjs/toolkit';
 import windyStore from "@windy/store";
 import * as skewTAct from "../actions/skewt";
 import * as soundingAct from "../actions/sounding";
-
-
 import { rootReducer } from "../reducers/sounding";
 
+export type AppStore = EnhancedStore<{ [K in keyof typeof rootReducer]: ReturnType<typeof rootReducer[K]> }>;
 
-let store: Store;
+let store: AppStore;
 
-export function getStore(container: HTMLDivElement) {
+export function getStore(container: HTMLDivElement): AppStore {
   if (store) {
     return store;
   }
 
-  const middlewares = [thunk];
-  const composeEnhancers =
-    (process.env.NODE_ENV == "development" ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ : null) ||
-    compose;
-    // TODO: check deprecated
-  store = createStore(rootReducer, composeEnhancers(applyMiddleware(...middlewares)));
+  // Automatically adds thunk and Redux DevTools
+  store = configureStore({
+    reducer: rootReducer,
+    devTools: process.env.NODE_ENV !== 'production'
+  });
 
   // TODO: mobile dimension
   const graphWith = container.clientWidth;
@@ -36,7 +33,7 @@ export function getStore(container: HTMLDivElement) {
   return store;
 }
 
-export function updateMetrics(store: Store) {
+export function updateMetrics(store: AppStore) {
   if (store) {
     store.dispatch(soundingAct.setMetricTemp(windyStore.get("metric_temp")));
     store.dispatch(soundingAct.setMetricAltitude(windyStore.get("metric_altitude")));


### PR DESCRIPTION
Switched from redux `createStore` to rtk `configureStore`.
Exported custom store type (`AppStore`) to include strong typing for the specifics of our state.

I want to have this pulled to see if we're on the right track, and this will play nicely before moving on. 

The next steps I see are using `slices` instead of actions/reducers explicitly, but that will take more time as there are some expections to the normal action and reducer patterns I see.
Ex: 'cancelSubscriptions' doesn't belong to a reducer in the way that the other actions do.
Also the functions `computeForecasts` and `forecasts` in the reducer for `sounding.ts` don't fit super nicely into the slice pattern, but we can make that work fine, if we want to go with slices.
